### PR TITLE
Add guest login with shared, reset-on-login account

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -150,6 +150,7 @@ func main() {
 
 	authRouter.HandleFunc("/register", authHandler.Register).Methods("POST", "OPTIONS")
 	authRouter.HandleFunc("/login", authHandler.Login).Methods("POST", "OPTIONS")
+	authRouter.HandleFunc("/guest-login", authHandler.GuestLogin).Methods("POST", "OPTIONS")
 	authRouter.HandleFunc("/refresh", authHandler.Refresh).Methods("POST", "OPTIONS")
 	authRouter.HandleFunc("/logout", authHandler.Logout).Methods("POST", "OPTIONS")
 

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"time"
@@ -8,6 +9,7 @@ import (
 	"github.com/diorshelton/golden-market-api/internal/models"
 	"github.com/diorshelton/golden-market-api/internal/repository"
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -152,6 +154,47 @@ func (s *AuthService) Login(
 	}
 
 	// Create a refresh token (using service's refreshTokenTTL)
+	refreshTokenObj, err := s.refreshTokenRepo.CreateRefreshToken(user.ID, s.refreshTokenTTL)
+	if err != nil {
+		return "", "", err
+	}
+
+	refreshToken = refreshTokenObj.Token
+
+	return accessToken, refreshToken, nil
+}
+
+// GuestLogin finds or creates the single shared guest account, wipes its
+// cart/inventory/order history on every login so each session starts fresh,
+// and returns access and refresh tokens like Login does.
+func (s *AuthService) GuestLogin() (accessToken string, refreshToken string, err error) {
+	user, err := s.userRepo.GetGuestUser()
+	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			return "", "", err
+		}
+
+		randomPassword := uuid.New().String()
+		hashedPassword, hashErr := hashPassword(randomPassword)
+		if hashErr != nil {
+			return "", "", hashErr
+		}
+
+		user, err = s.userRepo.CreateGuestUser(hashedPassword)
+		if err != nil {
+			return "", "", err
+		}
+	} else {
+		if err := s.userRepo.ResetGuestData(context.Background(), user.ID); err != nil {
+			return "", "", err
+		}
+	}
+
+	accessToken, err = s.generateAccessToken(user)
+	if err != nil {
+		return "", "", err
+	}
+
 	refreshTokenObj, err := s.refreshTokenRepo.CreateRefreshToken(user.ID, s.refreshTokenTTL)
 	if err != nil {
 		return "", "", err

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -199,6 +199,7 @@ func SetupDB() (*pgxpool.Pool, error) {
 		email VARCHAR(255) NOT NULL UNIQUE,
 		password_hash VARCHAR(255) NOT NULL,
 		balance INTEGER NOT NULL DEFAULT 5000 CHECK (balance >= 0),
+		is_guest BOOLEAN NOT NULL DEFAULT false,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
 		last_login TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 	);`
@@ -354,6 +355,9 @@ func runMigrations(ctx context.Context, db *pgxpool.Pool) error {
 
 	// Migration 2: Update default balance for users (doesn't affect existing users)
 	_, _ = db.Exec(ctx, `ALTER TABLE users ALTER COLUMN balance SET DEFAULT 5000`)
+
+	// Migration 3: Add is_guest flag for guest login accounts
+	_, _ = db.Exec(ctx, `ALTER TABLE users ADD COLUMN IF NOT EXISTS is_guest BOOLEAN NOT NULL DEFAULT false`)
 
 	return nil
 }

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -29,6 +29,7 @@ func refreshCookieAttrs() (http.SameSite, bool) {
 type AuthServiceInterface interface {
 	Register(firstName, lastName, email, username, password string) (*models.User, error)
 	Login(email, password string) (string, string, error)
+	GuestLogin() (string, string, error)
 	Refresh(oldRefreshToken string) (*auth.TokenPair, error)
 	Logout(refreshToken string) error
 }
@@ -214,6 +215,33 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 
 	response := LoginResponse{AccessToken: accessToken}
 	// Return access tokens
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}
+
+// GuestLogin handles login to the single shared guest account
+func (h *AuthHandler) GuestLogin(w http.ResponseWriter, r *http.Request) {
+	accessToken, refreshToken, err := h.authService.GuestLogin()
+	if err != nil {
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		log.Printf("Guest login error: %v", err)
+		return
+	}
+
+	maxAge := int((7 * 24 * time.Hour).Seconds())
+	sameSite, secure := refreshCookieAttrs()
+	http.SetCookie(w, &http.Cookie{
+		Name:     "refresh_token",
+		Value:    refreshToken,
+		Path:     "/",
+		MaxAge:   maxAge,
+		HttpOnly: true,
+		Secure:   secure,
+		SameSite: sameSite,
+		Expires:  time.Now().Add(7 * 24 * time.Hour),
+	})
+
+	response := LoginResponse{AccessToken: accessToken}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(response)
 }

--- a/internal/handlers/auth_test.go
+++ b/internal/handlers/auth_test.go
@@ -14,10 +14,11 @@ import (
 
 // Mock AuthService for testing
 type MockAuthService struct {
-	RegisterFunc func(firstName, lastName, email, username, password string) (*models.User, error)
-	LoginFunc    func(email, password string) (accessToken string, refreshToken string, err error)
-	RefreshFunc  func(oldRefreshToken string) (*auth.TokenPair, error)
-	LogoutFunc   func(tokenString string) error
+	RegisterFunc   func(firstName, lastName, email, username, password string) (*models.User, error)
+	LoginFunc      func(email, password string) (accessToken string, refreshToken string, err error)
+	GuestLoginFunc func() (accessToken string, refreshToken string, err error)
+	RefreshFunc    func(oldRefreshToken string) (*auth.TokenPair, error)
+	LogoutFunc     func(tokenString string) error
 }
 
 func (m *MockAuthService) Register(firstName, lastName, email, username, password string) (*models.User, error) {
@@ -26,6 +27,10 @@ func (m *MockAuthService) Register(firstName, lastName, email, username, passwor
 
 func (m *MockAuthService) Login(email, password string) (string, string, error) {
 	return m.LoginFunc(email, password)
+}
+
+func (m *MockAuthService) GuestLogin() (string, string, error) {
+	return m.GuestLoginFunc()
 }
 
 func (m *MockAuthService) Refresh(oldRefreshToken string) (*auth.TokenPair, error) {

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -15,6 +15,7 @@ type User struct {
 	Email        string    `json:"email"`
 	PasswordHash string    `json:"-"`
 	Balance      Coins     `json:"balance"`
+	IsGuest      bool      `json:"is_guest"`
 	Inventory    []Item    `json:"inventory,omitempty"`
 	CreatedAt    time.Time `json:"created_at"`
 	LastLogin    time.Time `json:"last_login"`

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -21,6 +21,12 @@ func NewUserRepository(db *pgxpool.Pool) *UserRepository {
 	return &UserRepository{db: db}
 }
 
+// Fixed identity for the single shared guest account
+const (
+	GuestUsername = "guest"
+	GuestEmail    = "guest@goldenmarket.local"
+)
+
 // CreateUser adds a new user to the database
 func (r *UserRepository) CreateUser(username, firstName, lastName, email, passwordHash string) (*models.User, error) {
 	user := &models.User{
@@ -93,6 +99,109 @@ func (r *UserRepository) GetUserByEmail(email string) (*models.User, error) {
 	}
 
 	return &user, nil
+}
+
+// GetGuestUser retrieves the single shared guest account, if it exists
+func (r *UserRepository) GetGuestUser() (*models.User, error) {
+	query := `
+		SELECT id, username, first_name, last_name, email, password_hash, balance, is_guest, created_at, last_login
+		FROM users
+		WHERE is_guest = true
+		LIMIT 1
+	`
+
+	var user models.User
+	var lastLogin sql.NullTime
+
+	ctx := context.Background()
+
+	err := r.db.QueryRow(ctx, query).Scan(
+		&user.ID,
+		&user.Username,
+		&user.FirstName,
+		&user.LastName,
+		&user.Email,
+		&user.PasswordHash,
+		&user.Balance,
+		&user.IsGuest,
+		&user.CreatedAt,
+		&lastLogin,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if lastLogin.Valid {
+		user.LastLogin = lastLogin.Time.UTC()
+	}
+
+	return &user, nil
+}
+
+// CreateGuestUser creates the single shared guest account
+func (r *UserRepository) CreateGuestUser(passwordHash string) (*models.User, error) {
+	user := &models.User{
+		ID:           uuid.New(),
+		Username:     GuestUsername,
+		FirstName:    "Guest",
+		LastName:     "User",
+		Email:        GuestEmail,
+		PasswordHash: passwordHash,
+		IsGuest:      true,
+		CreatedAt:    time.Now().UTC(),
+	}
+
+	query := `
+	INSERT INTO users (id, username, first_name, last_name, email, password_hash, is_guest, created_at, last_login)
+	VALUES ($1, $2, $3, $4, $5, $6, true, $7, $8)
+	RETURNING balance
+	`
+	ctx := context.Background()
+
+	err := r.db.QueryRow(
+		ctx,
+		query,
+		user.ID,
+		user.Username,
+		user.FirstName,
+		user.LastName,
+		user.Email,
+		user.PasswordHash,
+		user.CreatedAt,
+		user.LastLogin,
+	).Scan(&user.Balance)
+	if err != nil {
+		return nil, err
+	}
+
+	return user, nil
+}
+
+// ResetGuestData wipes the guest account's cart, inventory, and order history,
+// and resets its coin balance back to the starting amount. Runs in a transaction
+// so a partial reset never persists.
+func (r *UserRepository) ResetGuestData(ctx context.Context, userID uuid.UUID) error {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin guest reset transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	if _, err := tx.Exec(ctx, `DELETE FROM cart_items WHERE user_id = $1`, userID); err != nil {
+		return fmt.Errorf("failed to clear guest cart: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM inventory WHERE user_id = $1`, userID); err != nil {
+		return fmt.Errorf("failed to clear guest inventory: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM orders WHERE user_id = $1`, userID); err != nil {
+		return fmt.Errorf("failed to clear guest orders: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `UPDATE users SET balance = 5000 WHERE id = $1`, userID); err != nil {
+		return fmt.Errorf("failed to reset guest balance: %w", err)
+	}
+
+	return tx.Commit(ctx)
 }
 
 func (r *UserRepository) GetUserByUsername(username string) (*models.User, error) {


### PR DESCRIPTION
## Summary
- New `POST /auth/guest-login` endpoint backed by a single shared guest account (`is_guest` flag on `users`)
- Account is lazy-created on first use, and fully wiped (cart/inventory/orders deleted, balance reset to 5000) on every subsequent login so each guest session starts fresh
- Reuses the existing Login token-issuance path — real JWT, no fake/client-only auth state

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` pass
- [x] Verified end-to-end locally against a live Postgres instance: first call creates the guest account with a 5000 coin balance; after manually spending coins and adding a cart item, a second call resets the balance to 5000 and clears the cart while reusing the same guest account row