### PR TITLE
chore: fix render.yaml branch reference

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,7 @@ services:
     name: golden-market-api
     runtime: go
     plan: free
-    branch: develop
+    branch: main
     buildCommand: go build -o bin/api ./cmd/api
     startCommand: ./bin/api
     envVars:


### PR DESCRIPTION
## Summary
- \`render.yaml\` said \`branch: develop\`, but the Render dashboard actually deploys from \`main\` (confirmed manually in the dashboard)
- Companion to retiring \`develop\` as a long-lived branch in both repos — going forward, both repos use a single-trunk (\`main\`) convention with \`feature/\`, \`fix/\`, \`chore/\` branches, matching the existing CLAUDE.md convention

## Test plan
- [x] One-line config change, no build/runtime impact