### PR TITLE
refactor(config): centralize env var access into a config struct

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -73,7 +73,7 @@ func main() {
 	inventoryService := inventory.NewInventoryService(inventoryRepo)
 
 	// Create handlers
-	authHandler := handlers.NewAuthHandler(authService, cfg)
+	authHandler := handlers.NewAuthHandler(authService, cfg.Environment)
 	userHandler := handlers.NewUserHandler(userRepo)
 	productHandler := handlers.NewProductHandler(productService)
 	cartHandler := handlers.NewCartHandler(cartService)
@@ -85,7 +85,7 @@ func main() {
 	r := mux.NewRouter()
 
 	//Apply CORS middleware
-	corsMiddleware := middleware.CORS(cfg)
+	corsMiddleware := middleware.CORS(cfg.AllowedOrigins)
 	r.Use(corsMiddleware)
 
 	// --- Public API Endpoints --

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -5,11 +5,10 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"os"
-	"time"
 
 	"github.com/diorshelton/golden-market-api/internal/auth"
 	"github.com/diorshelton/golden-market-api/internal/cart"
+	"github.com/diorshelton/golden-market-api/internal/config"
 	"github.com/diorshelton/golden-market-api/internal/database"
 	"github.com/diorshelton/golden-market-api/internal/handlers"
 	"github.com/diorshelton/golden-market-api/internal/inventory"
@@ -18,42 +17,17 @@ import (
 	"github.com/diorshelton/golden-market-api/internal/product"
 	"github.com/diorshelton/golden-market-api/internal/repository"
 	"github.com/gorilla/mux"
-	"github.com/joho/godotenv"
 )
 
-// loadEnv loads environment variables from .env file
-func loadEnv() {
-	// Load .env file if it exists
-	if err := godotenv.Load(); err != nil {
-		log.Print("No .env file found, using environment variable")
-	}
-
-	// Check all required variables
-	requiredVars := []string{
-		"DATABASE_URL",
-		"JWT_SECRET",
-		"REFRESH_SECRET",
-		"ACCESS_TOKEN_EXPIRY",
-	}
-
-	missing := []string{}
-	for _, v := range requiredVars {
-		if os.Getenv(v) == "" {
-			missing = append(missing, v)
-		}
-	}
-
-	if len(missing) > 0 {
-		log.Fatalf("Required environment variable  %s is missing", missing)
-	}
-}
-
 func main() {
-	// Load environment variables
-	loadEnv()
+	// Load configuration
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	// Set up databases
-	database, err := database.SetupDB()
+	database, err := database.SetupDB(cfg.DatabaseURL)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -68,25 +42,14 @@ func main() {
 	orderItemRepo := repository.NewOrderItemRepository(database)
 	inventoryRepo := repository.NewInventoryRepository(database)
 
-	// Parse token duration
-	accessTTL, err := time.ParseDuration(os.Getenv("ACCESS_TOKEN_EXPIRY"))
-	if err != nil {
-		log.Fatalf("Invalid ACCESS_TOKEN_EXPIRY: %v", err)
-	}
-
-	refreshTTL, err := time.ParseDuration(os.Getenv("REFRESH_TOKEN_EXPIRY"))
-	if err != nil {
-		log.Fatalf("Invalid REFRESH_TOKEN_EXPIRY: %v", err)
-	}
-
 	// Create  auth service
 	authService := auth.NewAuthService(
 		userRepo,
 		tokenRepo,
-		os.Getenv("JWT_SECRET"),
-		os.Getenv("REFRESH_SECRET"),
-		accessTTL,
-		refreshTTL,
+		cfg.JWTSecret,
+		cfg.RefreshSecret,
+		cfg.AccessTokenExpiry,
+		cfg.RefreshTokenExpiry,
 	)
 
 	// Create product service
@@ -110,7 +73,7 @@ func main() {
 	inventoryService := inventory.NewInventoryService(inventoryRepo)
 
 	// Create handlers
-	authHandler := handlers.NewAuthHandler(authService)
+	authHandler := handlers.NewAuthHandler(authService, cfg)
 	userHandler := handlers.NewUserHandler(userRepo)
 	productHandler := handlers.NewProductHandler(productService)
 	cartHandler := handlers.NewCartHandler(cartService)
@@ -122,7 +85,8 @@ func main() {
 	r := mux.NewRouter()
 
 	//Apply CORS middleware
-	r.Use(middleware.CORS)
+	corsMiddleware := middleware.CORS(cfg)
+	r.Use(corsMiddleware)
 
 	// --- Public API Endpoints --
 	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -134,8 +98,8 @@ func main() {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
 			"status":      "ok",
-			"port":        os.Getenv("PORT"),
-			"environment": os.Getenv("ENVIRONMENT"),
+			"port":        cfg.Port,
+			"environment": cfg.Environment,
 		})
 	}).Methods("GET")
 
@@ -145,7 +109,7 @@ func main() {
 
 	// --- Auth API Endpoints (rate limited) ---
 	authRouter := r.PathPrefix("/api/v1/auth").Subrouter()
-	authRouter.Use(middleware.CORS)      // Apply CORS to Subrouter
+	authRouter.Use(corsMiddleware)       // Apply CORS to Subrouter
 	authRouter.Use(middleware.RateLimit) // Apply ratelimiting
 
 	authRouter.HandleFunc("/register", authHandler.Register).Methods("POST", "OPTIONS")
@@ -156,7 +120,7 @@ func main() {
 
 	// --- Protected routes ---
 	protected := r.PathPrefix("/api/v1").Subrouter()
-	protected.Use(middleware.CORS) // Apply CORS to Subrouter
+	protected.Use(corsMiddleware) // Apply CORS to Subrouter
 	protected.Use(middleware.Auth(authService))
 	protected.HandleFunc("/profile", userHandler.Profile).Methods("GET", "OPTIONS")
 
@@ -186,14 +150,9 @@ func main() {
 		protected.HandleFunc("/admin/users/{id}/inventory", adminHandler.ClearInventory).Methods("DELETE", "OPTIONS")
 	*/
 	// Start server
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "8080"
-	}
-
-	addr := ":" + port
-	log.Printf("Server starting on port %s", port)
-	log.Printf("Environment: %s", os.Getenv("ENVIRONMENT"))
+	addr := ":" + cfg.Port
+	log.Printf("Server starting on port %s", cfg.Port)
+	log.Printf("Environment: %s", cfg.Environment)
 
 	if err := http.ListenAndServe(addr, r); err != nil {
 		log.Fatal(err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,23 @@ type Config struct {
 	Environment        string
 }
 
+const redacted = "[REDACTED]"
+
+// String implements fmt.Stringer, redacting DatabaseURL (which embeds
+// credentials) and the JWT/refresh secrets so an accidental
+// log.Printf("%v", cfg) or similar doesn't leak them.
+func (c *Config) String() string {
+	return fmt.Sprintf(
+		"Config{DatabaseURL:%s JWTSecret:%s RefreshSecret:%s AccessTokenExpiry:%s RefreshTokenExpiry:%s AllowedOrigins:%v Port:%s Environment:%s}",
+		redacted, redacted, redacted, c.AccessTokenExpiry, c.RefreshTokenExpiry, c.AllowedOrigins, c.Port, c.Environment,
+	)
+}
+
+// GoString implements fmt.GoStringer, so "%#v" is redacted the same way.
+func (c *Config) GoString() string {
+	return c.String()
+}
+
 var defaultAllowedOrigins = []string{
 	"http://localhost:5173", // Vite default
 	"http://localhost:3000", // React default

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,95 @@
+package config
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/joho/godotenv"
+)
+
+type Config struct {
+	DatabaseURL        string
+	JWTSecret          string
+	RefreshSecret      string
+	AccessTokenExpiry  time.Duration
+	RefreshTokenExpiry time.Duration
+	AllowedOrigins     []string
+	Port               string
+	Environment        string
+}
+
+var defaultAllowedOrigins = []string{
+	"http://localhost:5173", // Vite default
+	"http://localhost:3000", // React default
+	"http://localhost:8080",
+}
+
+// Load reads configuration from environment variables (and .env, if present)
+// and returns a populated, validated Config.
+func Load() (*Config, error) {
+	if err := godotenv.Load(); err != nil {
+		log.Print("No .env file found, using environment variables")
+	}
+
+	required := map[string]string{
+		"DATABASE_URL":         "",
+		"JWT_SECRET":           "",
+		"REFRESH_SECRET":       "",
+		"ACCESS_TOKEN_EXPIRY":  "",
+		"REFRESH_TOKEN_EXPIRY": "",
+	}
+
+	missing := []string{}
+	for k := range required {
+		v := os.Getenv(k)
+		if v == "" {
+			missing = append(missing, k)
+		}
+		required[k] = v
+	}
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("required environment variable(s) missing: %s", strings.Join(missing, ", "))
+	}
+
+	accessTokenExpiry, err := time.ParseDuration(required["ACCESS_TOKEN_EXPIRY"])
+	if err != nil {
+		return nil, fmt.Errorf("invalid ACCESS_TOKEN_EXPIRY: %w", err)
+	}
+
+	refreshTokenExpiry, err := time.ParseDuration(required["REFRESH_TOKEN_EXPIRY"])
+	if err != nil {
+		return nil, fmt.Errorf("invalid REFRESH_TOKEN_EXPIRY: %w", err)
+	}
+
+	allowedOrigins := defaultAllowedOrigins
+	if raw := os.Getenv("ALLOWED_ORIGINS"); raw != "" {
+		allowedOrigins = nil
+		for _, origin := range strings.Split(raw, ",") {
+			allowedOrigins = append(allowedOrigins, strings.TrimSpace(origin))
+		}
+	}
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	environment := os.Getenv("ENVIRONMENT")
+	if environment == "" {
+		environment = "development"
+	}
+
+	return &Config{
+		DatabaseURL:        required["DATABASE_URL"],
+		JWTSecret:          required["JWT_SECRET"],
+		RefreshSecret:      required["REFRESH_SECRET"],
+		AccessTokenExpiry:  accessTokenExpiry,
+		RefreshTokenExpiry: refreshTokenExpiry,
+		AllowedOrigins:     allowedOrigins,
+		Port:               port,
+		Environment:        environment,
+	}, nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLoad(t *testing.T) {
+	validEnv := map[string]string{
+		"DATABASE_URL":         "postgres://user:pass@localhost:5432/db",
+		"JWT_SECRET":           "test-jwt-secret",
+		"REFRESH_SECRET":       "test-refresh-secret",
+		"ACCESS_TOKEN_EXPIRY":  "15m",
+		"REFRESH_TOKEN_EXPIRY": "168h",
+	}
+
+	tests := []struct {
+		name      string
+		overrides map[string]string
+		wantErr   bool
+	}{
+		{
+			name:    "all required vars set",
+			wantErr: false,
+		},
+		{
+			name:      "missing REFRESH_TOKEN_EXPIRY",
+			overrides: map[string]string{"REFRESH_TOKEN_EXPIRY": ""},
+			wantErr:   true,
+		},
+		{
+			name:      "invalid ACCESS_TOKEN_EXPIRY format",
+			overrides: map[string]string{"ACCESS_TOKEN_EXPIRY": "not-a-duration"},
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range validEnv {
+				t.Setenv(k, v)
+			}
+			for k, v := range tt.overrides {
+				t.Setenv(k, v)
+			}
+
+			cfg, err := Load()
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if cfg.DatabaseURL != validEnv["DATABASE_URL"] {
+				t.Errorf("DatabaseURL = %q, want %q", cfg.DatabaseURL, validEnv["DATABASE_URL"])
+			}
+			if cfg.AccessTokenExpiry != 15*time.Minute {
+				t.Errorf("AccessTokenExpiry = %v, want %v", cfg.AccessTokenExpiry, 15*time.Minute)
+			}
+			if cfg.RefreshTokenExpiry != 168*time.Hour {
+				t.Errorf("RefreshTokenExpiry = %v, want %v", cfg.RefreshTokenExpiry, 168*time.Hour)
+			}
+		})
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -67,5 +69,25 @@ func TestLoad(t *testing.T) {
 				t.Errorf("RefreshTokenExpiry = %v, want %v", cfg.RefreshTokenExpiry, 168*time.Hour)
 			}
 		})
+	}
+}
+
+func TestConfigStringRedactsSecrets(t *testing.T) {
+	cfg := &Config{
+		DatabaseURL:   "postgres://user:pass@localhost:5432/db",
+		JWTSecret:     "super-secret-jwt",
+		RefreshSecret: "super-secret-refresh",
+		Environment:   "development",
+	}
+
+	for _, got := range []string{fmt.Sprintf("%v", cfg), fmt.Sprintf("%+v", cfg), fmt.Sprintf("%#v", cfg)} {
+		for _, secret := range []string{cfg.DatabaseURL, cfg.JWTSecret, cfg.RefreshSecret} {
+			if strings.Contains(got, secret) {
+				t.Errorf("formatted output leaked a secret: %q contains %q", got, secret)
+			}
+		}
+		if !strings.Contains(got, redacted) {
+			t.Errorf("formatted output %q does not contain redaction marker %q", got, redacted)
+		}
 	}
 }

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -178,13 +178,12 @@ func SetupTestDB() (*pgxpool.Pool, error) {
 	return db, nil
 }
 
-func SetupDB() (*pgxpool.Pool, error) {
-	dbString := os.Getenv("DATABASE_URL")
-	if dbString == "" {
+func SetupDB(databaseURL string) (*pgxpool.Pool, error) {
+	if databaseURL == "" {
 		log.Fatal("DATABASE_URL not set in env")
 	}
 	ctx := context.Background()
-	db, err := pgxpool.New(ctx, dbString)
+	db, err := pgxpool.New(ctx, databaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to database: %w", err)
 	}

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/diorshelton/golden-market-api/internal/auth"
-	"github.com/diorshelton/golden-market-api/internal/config"
 	"github.com/diorshelton/golden-market-api/internal/models"
 )
 
@@ -20,7 +19,7 @@ import (
 // the browser to send the cookie on cross-origin requests. In development
 // both are on the same machine so Lax is sufficient and Secure is not required.
 func (h *AuthHandler) refreshCookieAttrs() (http.SameSite, bool) {
-	if h.cfg.Environment == "production" {
+	if h.environment == "production" {
 		return http.SameSiteNoneMode, true
 	}
 	return http.SameSiteLaxMode, false
@@ -37,14 +36,14 @@ type AuthServiceInterface interface {
 // AuthHandler contains HTTP handlers for authentication
 type AuthHandler struct {
 	authService AuthServiceInterface
-	cfg         *config.Config
+	environment string
 }
 
 // NewAuthHandler creates a new auth handler
-func NewAuthHandler(service AuthServiceInterface, cfg *config.Config) *AuthHandler {
+func NewAuthHandler(service AuthServiceInterface, environment string) *AuthHandler {
 	return &AuthHandler{
 		authService: service,
-		cfg:         cfg,
+		environment: environment,
 	}
 }
 

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -6,11 +6,11 @@ import (
 	"log"
 	"net/http"
 	"net/mail"
-	"os"
 	"strings"
 	"time"
 
 	"github.com/diorshelton/golden-market-api/internal/auth"
+	"github.com/diorshelton/golden-market-api/internal/config"
 	"github.com/diorshelton/golden-market-api/internal/models"
 )
 
@@ -19,8 +19,8 @@ import (
 // different domains, so SameSite must be None (with Secure=true) to allow
 // the browser to send the cookie on cross-origin requests. In development
 // both are on the same machine so Lax is sufficient and Secure is not required.
-func refreshCookieAttrs() (http.SameSite, bool) {
-	if os.Getenv("ENVIRONMENT") == "production" {
+func (h *AuthHandler) refreshCookieAttrs() (http.SameSite, bool) {
+	if h.cfg.Environment == "production" {
 		return http.SameSiteNoneMode, true
 	}
 	return http.SameSiteLaxMode, false
@@ -37,12 +37,14 @@ type AuthServiceInterface interface {
 // AuthHandler contains HTTP handlers for authentication
 type AuthHandler struct {
 	authService AuthServiceInterface
+	cfg         *config.Config
 }
 
 // NewAuthHandler creates a new auth handler
-func NewAuthHandler(service AuthServiceInterface) *AuthHandler {
+func NewAuthHandler(service AuthServiceInterface, cfg *config.Config) *AuthHandler {
 	return &AuthHandler{
 		authService: service,
+		cfg:         cfg,
 	}
 }
 
@@ -201,7 +203,7 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	}
 
 	maxAge := int((7 * 24 * time.Hour).Seconds())
-	sameSite, secure := refreshCookieAttrs()
+	sameSite, secure := h.refreshCookieAttrs()
 	http.SetCookie(w, &http.Cookie{
 		Name:     "refresh_token",
 		Value:    refreshToken,
@@ -229,7 +231,7 @@ func (h *AuthHandler) GuestLogin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	maxAge := int((7 * 24 * time.Hour).Seconds())
-	sameSite, secure := refreshCookieAttrs()
+	sameSite, secure := h.refreshCookieAttrs()
 	http.SetCookie(w, &http.Cookie{
 		Name:     "refresh_token",
 		Value:    refreshToken,
@@ -272,7 +274,7 @@ func (h *AuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	maxAge := int((7 * 24 * time.Hour).Seconds())
-	sameSite, secure := refreshCookieAttrs()
+	sameSite, secure := h.refreshCookieAttrs()
 	http.SetCookie(w, &http.Cookie{
 		Name:     "refresh_token",
 		Value:    tokenPair.RefreshToken,
@@ -292,7 +294,7 @@ func (h *AuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 	// Read refresh token from cookie
 	cookie, err := r.Cookie("refresh_token")
-	sameSite, secure := refreshCookieAttrs()
+	sameSite, secure := h.refreshCookieAttrs()
 	if err != nil {
 		http.SetCookie(w, &http.Cookie{
 			Name:     "refresh_token",

--- a/internal/handlers/auth_test.go
+++ b/internal/handlers/auth_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/diorshelton/golden-market-api/internal/auth"
+	"github.com/diorshelton/golden-market-api/internal/config"
 	"github.com/diorshelton/golden-market-api/internal/models"
 	"github.com/google/uuid"
 )
@@ -127,7 +128,7 @@ func TestRegisterHandler(t *testing.T) {
 			mockService := &MockAuthService{
 				RegisterFunc: tt.mockRegister,
 			}
-			handler := NewAuthHandler(mockService)
+			handler := NewAuthHandler(mockService, &config.Config{Environment: "development"})
 
 			jsonBody, _ := json.Marshal(tt.requestBody)
 			req := httptest.NewRequest(http.MethodPost, "/auth/register", bytes.NewBuffer(jsonBody))
@@ -197,7 +198,7 @@ func TestLoginHandler(t *testing.T) {
 			mockService := &MockAuthService{
 				LoginFunc: tt.mockLogin,
 			}
-			handler := NewAuthHandler(mockService)
+			handler := NewAuthHandler(mockService, &config.Config{Environment: "development"})
 
 			jsonBody, _ := json.Marshal(tt.requestBody)
 			req := httptest.NewRequest(http.MethodPost, "/auth/login", bytes.NewBuffer(jsonBody))
@@ -294,7 +295,7 @@ func TestRefreshHandler(t *testing.T) {
 			mockService := &MockAuthService{
 				RefreshFunc: tt.mockRefresh,
 			}
-			handler := NewAuthHandler(mockService)
+			handler := NewAuthHandler(mockService, &config.Config{Environment: "development"})
 
 			req := httptest.NewRequest(http.MethodPost, "/auth/refresh", nil)
 			tt.setupCookie(req)
@@ -346,7 +347,7 @@ func TestLogoutHandler(t *testing.T) {
 			mockService := &MockAuthService{
 				LogoutFunc: tt.mockLogout,
 			}
-			handler := NewAuthHandler(mockService)
+			handler := NewAuthHandler(mockService, &config.Config{Environment: "development"})
 
 			req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
 			tt.setupCookie(req)

--- a/internal/handlers/auth_test.go
+++ b/internal/handlers/auth_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/diorshelton/golden-market-api/internal/auth"
-	"github.com/diorshelton/golden-market-api/internal/config"
 	"github.com/diorshelton/golden-market-api/internal/models"
 	"github.com/google/uuid"
 )
@@ -128,7 +127,7 @@ func TestRegisterHandler(t *testing.T) {
 			mockService := &MockAuthService{
 				RegisterFunc: tt.mockRegister,
 			}
-			handler := NewAuthHandler(mockService, &config.Config{Environment: "development"})
+			handler := NewAuthHandler(mockService, "development")
 
 			jsonBody, _ := json.Marshal(tt.requestBody)
 			req := httptest.NewRequest(http.MethodPost, "/auth/register", bytes.NewBuffer(jsonBody))
@@ -198,7 +197,7 @@ func TestLoginHandler(t *testing.T) {
 			mockService := &MockAuthService{
 				LoginFunc: tt.mockLogin,
 			}
-			handler := NewAuthHandler(mockService, &config.Config{Environment: "development"})
+			handler := NewAuthHandler(mockService, "development")
 
 			jsonBody, _ := json.Marshal(tt.requestBody)
 			req := httptest.NewRequest(http.MethodPost, "/auth/login", bytes.NewBuffer(jsonBody))
@@ -295,7 +294,7 @@ func TestRefreshHandler(t *testing.T) {
 			mockService := &MockAuthService{
 				RefreshFunc: tt.mockRefresh,
 			}
-			handler := NewAuthHandler(mockService, &config.Config{Environment: "development"})
+			handler := NewAuthHandler(mockService, "development")
 
 			req := httptest.NewRequest(http.MethodPost, "/auth/refresh", nil)
 			tt.setupCookie(req)
@@ -347,7 +346,7 @@ func TestLogoutHandler(t *testing.T) {
 			mockService := &MockAuthService{
 				LogoutFunc: tt.mockLogout,
 			}
-			handler := NewAuthHandler(mockService, &config.Config{Environment: "development"})
+			handler := NewAuthHandler(mockService, "development")
 
 			req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
 			tt.setupCookie(req)

--- a/internal/middleware/cors.go
+++ b/internal/middleware/cors.go
@@ -2,57 +2,49 @@ package middleware
 
 import (
 	"net/http"
-	"os"
 	"strings"
+
+	"github.com/diorshelton/golden-market-api/internal/config"
 )
 
-// CORS handles Cross-Origin Resource Sharing
-func CORS(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		allowedOriginsEnv := os.Getenv("ALLOWED_ORIGINS")
-		var allowedOrigins []string
+// CORS returns middleware that handles Cross-Origin Resource Sharing,
+// using the allowed origins from cfg.
+func CORS(cfg *config.Config) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			allowedOrigins := cfg.AllowedOrigins
 
-		if allowedOriginsEnv != "" {
-			allowedOrigins = strings.Split(allowedOriginsEnv, ",")
-		} else {
-			// Default allowed origins for development
-			allowedOrigins = []string{
-				"http://localhost:5173", // Vite default
-				"http://localhost:3000", // React default
-				"http://localhost:8080",
+			origin := r.Header.Get("Origin")
+
+			// Check if origin is allowed
+			allowed := false
+			for _, allowedOrigin := range allowedOrigins {
+				if strings.TrimSpace(allowedOrigin) == origin {
+					allowed = true
+					break
+				}
 			}
-		}
 
-		origin := r.Header.Get("Origin")
+			// Set CORS headers if origin is allowed
+			if allowed {
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+				w.Header().Set("Access-Control-Allow-Credentials", "true")
+				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PATCH, PUT, DELETE, OPTIONS")
+				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+				w.Header().Set("Access-Control-Max-Age", "3600")
 
-		// Check if origin is allowed
-		allowed := false
-		for _, allowedOrigin := range allowedOrigins {
-			if strings.TrimSpace(allowedOrigin) == origin {
-				allowed = true
-				break
-			}
-		}
-
-		// Set CORS headers if origin is allowed
-		if allowed {
-			w.Header().Set("Access-Control-Allow-Origin", origin)
-			w.Header().Set("Access-Control-Allow-Credentials", "true")
-			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PATCH, PUT, DELETE, OPTIONS")
-			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
-			w.Header().Set("Access-Control-Max-Age", "3600")
-
-			// Handle preflight requests (only for allowed origins)
-			if r.Method == "OPTIONS" {
-				w.WriteHeader(http.StatusNoContent)
+				// Handle preflight requests (only for allowed origins)
+				if r.Method == "OPTIONS" {
+					w.WriteHeader(http.StatusNoContent)
+					return
+				}
+			} else if r.Method == "OPTIONS" {
+				// Reject preflight from disallowed origins
+				w.WriteHeader(http.StatusForbidden)
 				return
 			}
-		} else if r.Method == "OPTIONS" {
-			// Reject preflight from disallowed origins
-			w.WriteHeader(http.StatusForbidden)
-			return
-		}
 
-		next.ServeHTTP(w, r)
-	})
+			next.ServeHTTP(w, r)
+		})
+	}
 }

--- a/internal/middleware/cors.go
+++ b/internal/middleware/cors.go
@@ -3,17 +3,13 @@ package middleware
 import (
 	"net/http"
 	"strings"
-
-	"github.com/diorshelton/golden-market-api/internal/config"
 )
 
 // CORS returns middleware that handles Cross-Origin Resource Sharing,
-// using the allowed origins from cfg.
-func CORS(cfg *config.Config) func(http.Handler) http.Handler {
+// permitting only the given allowedOrigins.
+func CORS(allowedOrigins []string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			allowedOrigins := cfg.AllowedOrigins
-
 			origin := r.Header.Get("Origin")
 
 			// Check if origin is allowed

--- a/internal/repository/product_test.go
+++ b/internal/repository/product_test.go
@@ -27,7 +27,7 @@ func TestProductRepository(t *testing.T) {
 		t.Skip("TEST_DB_URL not set, skipping database tests")
 	}
 
-	dbConnection, err := database.SetupDB()
+	dbConnection, err := database.SetupDB(os.Getenv("DATABASE_URL"))
 	if err != nil {
 		t.Fatalf("An error occurred: %v", err)
 	}


### PR DESCRIPTION
# Summary
Replace ad hoc` os.Getenv` calls across `main.go, db.go, cors.go`, and `auth.go` with a single `internal/config.Config` loaded once at startup. Also fixes a validation gap where` REFRESH_TOKEN_EXPIRY` wasn't checked by the old `required-vars` list, so a bad value failed late instead of at startup.